### PR TITLE
Implement moderation utilities and logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,13 +1,20 @@
+import html
 import os
 import logging
+import time
+from collections import defaultdict
+from typing import Any, Dict, List
+
 import firebase_admin
 from firebase_admin import credentials, db
-from telegram import Update, ChatPermissions
+from telegram import ChatPermissions, Update
 from telegram.ext import (
-    ApplicationBuilder, CommandHandler, MessageHandler, ContextTypes, filters
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
 )
-from collections import defaultdict
-import time
 
 logging.basicConfig(level=logging.INFO)
 
@@ -34,6 +41,74 @@ if not BOT_TOKEN:
 user_message_times = defaultdict(list)
 
 # Helper functions
+FIREBASE_INVALID_KEY_CHARS = (".", "#", "$", "[", "]", "/")
+
+
+def sanitize_key(key: str) -> str:
+    sanitized = key
+    for char in FIREBASE_INVALID_KEY_CHARS:
+        sanitized = sanitized.replace(char, "_")
+    return sanitized
+
+
+def ensure_list(raw: Any) -> List[str]:
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return [entry for entry in raw if isinstance(entry, str)]
+    if isinstance(raw, dict):
+        ordered_keys = sorted(raw.keys())
+        return [raw[key] for key in ordered_keys if isinstance(raw[key], str)]
+    return []
+
+
+def normalize_filters(raw: Any) -> Dict[str, Dict[str, str]]:
+    result: Dict[str, Dict[str, str]] = {}
+    if not isinstance(raw, dict):
+        return result
+    for key, value in raw.items():
+        if isinstance(value, dict):
+            trigger = value.get("trigger")
+            reply = value.get("reply")
+            if trigger and reply is not None:
+                result[str(key)] = {
+                    "trigger": str(trigger),
+                    "reply": str(reply),
+                }
+        elif isinstance(value, str):
+            result[str(key)] = {"trigger": str(key), "reply": value}
+    return result
+
+
+def get_filters(chat_id: int) -> Dict[str, Dict[str, str]]:
+    return normalize_filters(group_ref(chat_id).child("filters").get())
+
+
+def update_name_history(user) -> None:
+    if user is None:
+        return
+    history_ref = user_ref(user.id).child("history")
+    history = ensure_list(history_ref.get())
+    new_name = f"{user.first_name or ''} {user.last_name or ''} (@{user.username or 'no_username'})".strip()
+    if not history or history[-1] != new_name:
+        history.append(new_name)
+        history_ref.set(history)
+
+
+async def send_log(context: ContextTypes.DEFAULT_TYPE, chat_id: int, text: str) -> None:
+    log_chat_id = group_ref(chat_id).child("log_channel").get()
+    if not log_chat_id:
+        return
+    try:
+        target_chat = int(str(log_chat_id))
+    except (TypeError, ValueError):
+        target_chat = log_chat_id
+    try:
+        await context.bot.send_message(chat_id=target_chat, text=text, parse_mode="HTML")
+    except Exception:
+        logging.warning("Failed to send log message for chat %s", chat_id, exc_info=True)
+
+
 def is_admin(user_id: int) -> bool:
     return ADMINS_REF.child(str(user_id)).get() is True
 
@@ -103,17 +178,33 @@ async def set_welcome(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not is_admin(update.effective_user.id):
         await update.message.reply_text("🚫 Only admins can set welcome message.")
         return
-    text = " ".join(context.args)
+    if not context.args:
+        await update.message.reply_text("Usage: /setwelcome <text>")
+        return
+    text = " ".join(context.args).strip()
     group_ref(update.effective_chat.id).update({"welcome_text": text})
     await update.message.reply_text(f"✅ Welcome message set to:\n{text}")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"📝 Welcome message updated by {update.effective_user.mention_html()}: {html.escape(text)}",
+    )
 
 async def set_goodbye(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not is_admin(update.effective_user.id):
         await update.message.reply_text("🚫 Only admins can set goodbye message.")
         return
-    text = " ".join(context.args)
+    if not context.args:
+        await update.message.reply_text("Usage: /setgoodbye <text>")
+        return
+    text = " ".join(context.args).strip()
     group_ref(update.effective_chat.id).update({"goodbye_text": text})
     await update.message.reply_text(f"✅ Goodbye message set to:\n{text}")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"📤 Goodbye message updated by {update.effective_user.mention_html()}: {html.escape(text)}",
+    )
 
 async def toggle_welcome(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not is_admin(update.effective_user.id):
@@ -126,6 +217,11 @@ async def toggle_welcome(update: Update, context: ContextTypes.DEFAULT_TYPE):
     group_ref(update.effective_chat.id).update({"welcome_on": status})
     await update.message.reply_text(
         f"✅ Welcome messages {'enabled' if status else 'disabled'}."
+    )
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🔔 Welcome messages {'enabled' if status else 'disabled'} by {update.effective_user.mention_html()}.",
     )
 
 async def toggle_goodbye(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -140,6 +236,137 @@ async def toggle_goodbye(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text(
         f"✅ Goodbye messages {'enabled' if status else 'disabled'}."
     )
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🔔 Goodbye messages {'enabled' if status else 'disabled'} by {update.effective_user.mention_html()}.",
+    )
+
+# -----------------------
+# Filters, Flood & Logging
+# -----------------------
+async def set_flood(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not is_admin(update.effective_user.id):
+        await update.message.reply_text("🚫 Only admins can set flood limit.")
+        return
+    if not context.args:
+        await update.message.reply_text("Usage: /setflood <number>")
+        return
+    try:
+        limit = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("Flood limit must be a number.")
+        return
+    if limit < 1:
+        await update.message.reply_text("Flood limit must be at least 1.")
+        return
+    group_ref(update.effective_chat.id).update({"flood_limit": limit})
+    await update.message.reply_text(f"✅ Flood limit set to {limit} messages per 10 seconds.")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🌊 Flood limit set to {limit} by {update.effective_user.mention_html()}.",
+    )
+
+
+async def add_filter(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not is_admin(update.effective_user.id):
+        await update.message.reply_text("🚫 Only admins can add filters.")
+        return
+    if len(context.args) < 2:
+        await update.message.reply_text("Usage: /addfilter <word> <reply>")
+        return
+    trigger = context.args[0]
+    reply_text = " ".join(context.args[1:]).strip()
+    if not reply_text:
+        await update.message.reply_text("Reply text cannot be empty.")
+        return
+    key = sanitize_key(trigger.lower())
+    filters_data = get_filters(update.effective_chat.id)
+    filters_data[key] = {"trigger": trigger, "reply": reply_text}
+    group_ref(update.effective_chat.id).child("filters").set(filters_data)
+    await update.message.reply_text(f"✅ Filter added for '{trigger}'.")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🛡️ Filter '<b>{html.escape(trigger)}</b>' added by {update.effective_user.mention_html()}.",
+    )
+
+
+async def delete_filter(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not is_admin(update.effective_user.id):
+        await update.message.reply_text("🚫 Only admins can delete filters.")
+        return
+    if not context.args:
+        await update.message.reply_text("Usage: /delfilter <word>")
+        return
+    trigger = context.args[0]
+    key = sanitize_key(trigger.lower())
+    filters_data = get_filters(update.effective_chat.id)
+    removed = filters_data.pop(key, None)
+    if removed is None:
+        await update.message.reply_text(f"No filter found for '{trigger}'.")
+        return
+    group_ref(update.effective_chat.id).child("filters").set(filters_data)
+    await update.message.reply_text(f"✅ Filter '{trigger}' removed.")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🧹 Filter '<b>{html.escape(trigger)}</b>' removed by {update.effective_user.mention_html()}.",
+    )
+
+
+async def list_filters(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    del context  # unused
+    filters_data = get_filters(update.effective_chat.id)
+    if not filters_data:
+        await update.message.reply_text("No filters configured.")
+        return
+    sorted_filters = sorted(
+        filters_data.values(), key=lambda item: item.get("trigger", "").lower()
+    )
+    lines = [f"• {item['trigger']} → {item['reply']}" for item in sorted_filters]
+    await update.message.reply_text("Current filters:\n" + "\n".join(lines))
+
+
+async def set_log_channel(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not is_admin(update.effective_user.id):
+        await update.message.reply_text("🚫 Only admins can set log channel.")
+        return
+    if not context.args:
+        await update.message.reply_text("Usage: /setlog <chat_id>")
+        return
+    target = context.args[0]
+    group_ref(update.effective_chat.id).update({"log_channel": target})
+    await update.message.reply_text(f"✅ Log channel set to {target}.")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🗒️ Log channel updated by {update.effective_user.mention_html()} to {html.escape(target)}.",
+    )
+
+
+async def unset_log_channel(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if not is_admin(update.effective_user.id):
+        await update.message.reply_text("🚫 Only admins can unset log channel.")
+        return
+    if group_ref(update.effective_chat.id).child("log_channel").get():
+        await send_log(
+            context,
+            update.effective_chat.id,
+            f"🗒️ Log channel removed by {update.effective_user.mention_html()}.",
+        )
+    group_ref(update.effective_chat.id).child("log_channel").delete()
+    await update.message.reply_text("✅ Log channel removed.")
+
+
+async def log_status(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    del context  # unused
+    log_chat_id = group_ref(update.effective_chat.id).child("log_channel").get()
+    if log_chat_id:
+        await update.message.reply_text(f"ℹ️ Logging to chat ID: {log_chat_id}")
+    else:
+        await update.message.reply_text("ℹ️ Logging channel not configured.")
 
 # -----------------------
 # Moderation Commands
@@ -156,9 +383,14 @@ async def ban(update: Update, context: ContextTypes.DEFAULT_TYPE):
     group_ref(chat_id).child("blacklist").child(str(target.id)).set(True)
     try:
         await update.effective_chat.ban_member(target.id)
-    except:
-        pass
+    except Exception:
+        logging.debug("Failed to ban user %s in chat %s", target.id, chat_id, exc_info=True)
     await update.message.reply_text(f"🚫 {target.mention_html()} banned.", parse_mode="HTML")
+    await send_log(
+        context,
+        chat_id,
+        f"🚫 {target.mention_html()} banned by {update.effective_user.mention_html()}.",
+    )
 
 async def unban(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not update.message.reply_to_message:
@@ -172,9 +404,14 @@ async def unban(update: Update, context: ContextTypes.DEFAULT_TYPE):
     group_ref(chat_id).child("blacklist").child(str(target.id)).delete()
     try:
         await update.effective_chat.unban_member(target.id)
-    except:
-        pass
+    except Exception:
+        logging.debug("Failed to unban user %s in chat %s", target.id, chat_id, exc_info=True)
     await update.message.reply_text(f"✅ {target.mention_html()} unbanned.", parse_mode="HTML")
+    await send_log(
+        context,
+        chat_id,
+        f"✅ {target.mention_html()} unbanned by {update.effective_user.mention_html()}.",
+    )
 
 async def kick(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not update.message.reply_to_message:
@@ -187,9 +424,14 @@ async def kick(update: Update, context: ContextTypes.DEFAULT_TYPE):
     try:
         await update.effective_chat.ban_member(target.id)
         await update.effective_chat.unban_member(target.id)
-    except:
-        pass
+    except Exception:
+        logging.debug("Failed to kick user %s in chat %s", target.id, update.effective_chat.id, exc_info=True)
     await update.message.reply_text(f"👢 {target.mention_html()} kicked.", parse_mode="HTML")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"👢 {target.mention_html()} kicked by {update.effective_user.mention_html()}.",
+    )
 
 async def mute(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not update.message.reply_to_message:
@@ -201,6 +443,11 @@ async def mute(update: Update, context: ContextTypes.DEFAULT_TYPE):
     target = update.message.reply_to_message.from_user
     await update.effective_chat.restrict_member(target.id, permissions=ChatPermissions(can_send_messages=False))
     await update.message.reply_text(f"🔇 {target.mention_html()} muted.", parse_mode="HTML")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🔇 {target.mention_html()} muted by {update.effective_user.mention_html()}.",
+    )
 
 async def unmute(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not update.message.reply_to_message:
@@ -212,31 +459,40 @@ async def unmute(update: Update, context: ContextTypes.DEFAULT_TYPE):
     target = update.message.reply_to_message.from_user
     await update.effective_chat.restrict_member(target.id, permissions=ChatPermissions(can_send_messages=True))
     await update.message.reply_text(f"🔊 {target.mention_html()} unmuted.", parse_mode="HTML")
+    await send_log(
+        context,
+        update.effective_chat.id,
+        f"🔊 {target.mention_html()} unmuted by {update.effective_user.mention_html()}.",
+    )
 
 # -----------------------
 # Name History (Sangmata)
 # -----------------------
 async def track_name(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    del context  # unused
     user = update.effective_user
-    history = user_ref(user.id).child("history").get() or []
-    new_name = f"{user.first_name} {user.last_name or ''} (@{user.username or 'no_username'})"
-    if not history or history[-1] != new_name:
-        user_ref(user.id).child("history").push(new_name)
+    update_name_history(user)
 
 async def history(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if context.args:
         username = context.args[0].lstrip("@")
         all_users = USERS_REF.get() or {}
         for uid, data in all_users.items():
-            if any(username in h for h in data.get("history", [])):
-                hist = "\n".join(data.get("history", []))
+            if not isinstance(data, dict):
+                continue
+            hist_entries = ensure_list(data.get("history"))
+            if any(username.lower() in entry.lower() for entry in hist_entries):
+                hist = "\n".join(hist_entries) if hist_entries else "No history recorded."
                 await update.message.reply_text(f"History of {username}:\n{hist}")
                 return
         await update.message.reply_text("User not found.")
     else:
         user_id = update.effective_user.id
-        hist = user_ref(user_id).child("history").get() or []
-        await update.message.reply_text("Your name history:\n" + "\n".join(hist))
+        hist = ensure_list(user_ref(user_id).child("history").get())
+        if hist:
+            await update.message.reply_text("Your name history:\n" + "\n".join(hist))
+        else:
+            await update.message.reply_text("No name history recorded yet.")
 
 # -----------------------
 # Message Handler (Flood, Filters, Auto Ban)
@@ -248,32 +504,82 @@ async def check_messages(update: Update, context: ContextTypes.DEFAULT_TYPE):
         # Nothing to do for updates without a message payload (e.g. joins, callbacks)
         return
 
-    user = update.effective_user
-    chat_id = update.effective_chat.id
-    # Track name
-    await track_name(update, context)
-    # Auto-ban
+    chat = update.effective_chat
+    if chat is None:
+        return
+    chat_id = chat.id
+
+    if message.new_chat_members:
+        welcome_on = group_ref(chat_id).child("welcome_on").get()
+        welcome_text = group_ref(chat_id).child("welcome_text").get() or "Welcome, {first}!"
+        for member in message.new_chat_members:
+            update_name_history(member)
+            if welcome_on:
+                await message.reply_text(format_name_vars(welcome_text, member))
+            await send_log(
+                context,
+                chat_id,
+                f"👋 {member.mention_html()} joined {html.escape(chat.title or 'the chat')}.",
+            )
+        return
+
+    if message.left_chat_member:
+        member = message.left_chat_member
+        update_name_history(member)
+        goodbye_on = group_ref(chat_id).child("goodbye_on").get()
+        goodbye_text = group_ref(chat_id).child("goodbye_text").get() or "Goodbye, {first}!"
+        if goodbye_on:
+            await message.reply_text(format_name_vars(goodbye_text, member))
+        await send_log(
+            context,
+            chat_id,
+            f"👋 {member.mention_html()} left {html.escape(chat.title or 'the chat')}.",
+        )
+        return
+
+    user = message.from_user
+    if user is None:
+        return
+
+    update_name_history(user)
+
     if is_banned(chat_id, user.id):
         try:
-            await update.effective_chat.ban_member(user.id)
-        except:
-            pass
+            await chat.ban_member(user.id)
+        except Exception:
+            logging.debug("Failed to re-ban user %s", user.id, exc_info=True)
+        await send_log(
+            context,
+            chat_id,
+            f"⛔ Blocked message from banned user {user.mention_html()}.",
+        )
         return
-    # Flood control
+
     now = time.time()
-    user_message_times[(chat_id, user.id)].append(now)
-    user_message_times[(chat_id, user.id)] = [t for t in user_message_times[(chat_id, user.id)] if now - t < 10]
+    user_key = (chat_id, user.id)
+    user_message_times[user_key].append(now)
+    user_message_times[user_key] = [t for t in user_message_times[user_key] if now - t < 10]
     flood_limit = group_ref(chat_id).child("flood_limit").get() or 5
-    if len(user_message_times[(chat_id, user.id)]) > flood_limit:
-        await update.effective_chat.restrict_member(user.id, permissions=ChatPermissions(can_send_messages=False))
+    if len(user_message_times[user_key]) > flood_limit:
+        await chat.restrict_member(user.id, permissions=ChatPermissions(can_send_messages=False))
         await message.reply_text(f"🚨 {user.mention_html()} muted for flooding.", parse_mode="HTML")
+        await send_log(
+            context,
+            chat_id,
+            f"🚨 {user.mention_html()} muted for flooding (> {flood_limit} msgs/10s).",
+        )
+        user_message_times[user_key].clear()
         return
-    # Filters
-    filters_dict = group_ref(chat_id).child("filters").get() or {}
+
+    filters_dict = get_filters(chat_id)
     text = message.text or message.caption or ""
-    for word, reply in filters_dict.items():
-        if word.lower() in text.lower():
-            await message.reply_text(reply)
+    lowered = text.lower()
+    for data in filters_dict.values():
+        trigger = data.get("trigger", "")
+        reply_text = data.get("reply", "")
+        if trigger and reply_text and trigger.lower() in lowered:
+            await message.reply_text(reply_text)
+            break
 
 # -----------------------
 # Main
@@ -288,6 +594,13 @@ if __name__ == "__main__":
     app.add_handler(CommandHandler("setgoodbye", set_goodbye))
     app.add_handler(CommandHandler("welcome", toggle_welcome))
     app.add_handler(CommandHandler("goodbye", toggle_goodbye))
+    app.add_handler(CommandHandler("setflood", set_flood))
+    app.add_handler(CommandHandler("addfilter", add_filter))
+    app.add_handler(CommandHandler("delfilter", delete_filter))
+    app.add_handler(CommandHandler("filters", list_filters))
+    app.add_handler(CommandHandler("setlog", set_log_channel))
+    app.add_handler(CommandHandler("unsetlog", unset_log_channel))
+    app.add_handler(CommandHandler("logstatus", log_status))
     app.add_handler(CommandHandler("ban", ban))
     app.add_handler(CommandHandler("unban", unban))
     app.add_handler(CommandHandler("kick", kick))


### PR DESCRIPTION
## Summary
- add helper utilities for Firebase-backed filters, user history tracking, and log dispatching
- implement filter, flood, and logging configuration commands alongside richer moderation logging
- enhance message handling for welcomes, goodbyes, bans, flooding, and history lookups

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68ce5987d5048322a98f1c30dd45d8a6