### PR TITLE
Remove unnecessary firebase volume from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,4 @@ services:
     restart: always
     env_file:
       - .env
-    volumes:
-      - ./firebase-service-account.json:/app/firebase-service-account.json
     command: python bot.py


### PR DESCRIPTION
## Summary
- remove the firebase credential bind mount from docker-compose since the image already includes the file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d06361c4708322bd29000b67cefb95