### PR TITLE
Allow environment-based Firebase credential configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ Telegram group moderation bot inspired by GroupHelpBot/Rose.
 
 
 ## Setup
-1. Place Firebase service account JSON in project root.
+1. Provide the Firebase service account credentials using one of the supported options:
 
-   ```firebase-service-account.json```
+   - Place the JSON file (for example `firebase-service-account.json`) in the project root and set `FIREBASE_CRED` to the file
+     name or relative path.
+   - Set `FIREBASE_CRED_JSON` to the raw JSON string.
+   - Set `FIREBASE_CRED_BASE64` to the base64 encoded JSON content (useful when the JSON contains newlines that are hard to
+     express in environment files).
 
-2. Fill out `.env` file.
+2. Fill out `.env` file with your bot token, Firebase database URL, and one of the credential variables above.
 3. Build and run using Docker:
 
    ```


### PR DESCRIPTION
## Summary
- add a helper that loads Firebase credentials from a file path, JSON string, or base64 value defined in the environment
- update the README to document the new credential configuration options

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d07407237883229b42c6bf7fee8f26