### PR TITLE
Update Firebase service account file naming

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BOT_TOKEN=8327763636:AAF7Uq9i2-DaAf6gfoaYOH2LdZnq_oyo8s0
 FIREBASE_DB_URL=https://telelog69.firebaseio.com/
-FIREBASE_CRED="E:\New folder (2)\BreakTheIcx\firebase-service-account.json"
+FIREBASE_CRED="E:\New folder (2)\BreakTheIcx\serviceAccountkey.json"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 firebase-service-account.json
+serviceAccountkey.json
 __pycache__/
 *.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY bot.py .
-COPY firebase-service-account.json .
+COPY serviceAccountkey.json .
 
 ENV BOT_TOKEN=""
-ENV FIREBASE_CRED="/app/firebase-service-account.json"
+ENV FIREBASE_CRED="/app/serviceAccountkey.json"
 ENV FIREBASE_DB_URL=""
 
 CMD ["python", "bot.py"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Telegram group moderation bot inspired by GroupHelpBot/Rose.
 ## Setup
 1. Provide the Firebase service account credentials using one of the supported options:
 
-   - Place the JSON file (for example `firebase-service-account.json`) in the project root and set `FIREBASE_CRED` to the file
+   - Place the JSON file (for example `serviceAccountkey.json`) in the project root and set `FIREBASE_CRED` to the file
      name or relative path.
    - Set `FIREBASE_CRED_JSON` to the raw JSON string.
    - Set `FIREBASE_CRED_BASE64` to the base64 encoded JSON content (useful when the JSON contains newlines that are hard to


### PR DESCRIPTION
## Summary
- update the Dockerfile to expect `serviceAccountkey.json` and adjust the default `FIREBASE_CRED` path
- document the new credential filename and ensure it is ignored by git
- refresh the sample `.env` to reference the renamed service account file

## Testing
- python -m compileall bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d13a89d4d88322bde6bff406679e66